### PR TITLE
fix: Change edition from 2024 to 2018 for Compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mate"
 version = "0.1.0"
-edition = "2024"
+edition = "2018"
 authors = ["Kanishk Pachauri <itskanishkp.py@gmail.com>"]
 license = "MIT"
 description = "A tool to easily add co-authors to your Git commits"


### PR DESCRIPTION
### Description:
This PR changes the ```edition``` in the ```Cargo.toml``` file from ```2024``` to ```2018``` to ensure compatibility with all the stable versions of Cargo.

Before:

Unable to install the package

Screenshots:
![image](https://github.com/user-attachments/assets/7a8793b8-0e0b-4e19-bb77-c4b8957d61cb)

```
cargo check
error: failed to parse manifest at `/home/coderaholic/j/mate/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.82.0 (8f40fc59f 2024-08-21)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```

After:
```
 cargo check
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
```